### PR TITLE
ref: completely remove storage for stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Features, that can buy you in:
 - `KOMPANION_PG_URL` - postgresql link
 - `KOMPANION_BSTORAGE_TYPE` - type of storage for books: postgres, memory, filesystem (default: postgres)
 - `KOMPANION_BSTORAGE_PATH` - path in case of filesystem
-- `KOMPANION_STATS_TYPE` - type of temporary storage for uploaded sqlite3 stats files: postgres, memory, filesystem (default: memory)
-- `KOMPANION_STATS_PATH` - path in case of filesystem
 
 ## Usage
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,6 @@ type (
 		Log
 		PG
 		BookStorage
-		StatsStorage
 	}
 
 	// App -.
@@ -52,12 +51,6 @@ type (
 		Type string
 		Path string
 	}
-
-	// StatsStorage -.
-	StatsStorage struct {
-		Type string
-		Path string
-	}
 )
 
 // NewConfig - reads from env, validates and returns the config.
@@ -87,22 +80,16 @@ func NewConfig(version string) (*Config, error) {
 		return nil, err
 	}
 
-	statsStorage, err := readStatsStorageConfig()
-	if err != nil {
-		return nil, err
-	}
-
 	return &Config{
 		App: App{
 			Name:    "kompanion",
 			Version: version,
 		},
-		Auth:         auth,
-		HTTP:         http,
-		Log:          log,
-		PG:           postgres,
-		BookStorage:  bookStorage,
-		StatsStorage: statsStorage,
+		Auth:        auth,
+		HTTP:        http,
+		Log:         log,
+		PG:          postgres,
+		BookStorage: bookStorage,
 	}, nil
 }
 
@@ -181,18 +168,6 @@ func readBookStorageConfig() (BookStorage, error) {
 	return BookStorage{
 		Type: bstorage_type,
 		Path: bstorage_path,
-	}, nil
-}
-
-func readStatsStorageConfig() (StatsStorage, error) {
-	stats_type := readPrefixedEnv("STATS_TYPE")
-	if stats_type == "" {
-		stats_type = "postgres"
-	}
-	stats_path := readPrefixedEnv("STATS_PATH")
-	return StatsStorage{
-		Type: stats_type,
-		Path: stats_path,
 	}, nil
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - ./data:/data
     environment:
       KOMPANION_PG_URL: 'postgres://user:pass@postgres:5432/postgres'
-      KOMPANION_STATS_PATH: '/data/stats/'
       KOMPANION_BSTORAGE_PATH: '/data/books/'
       KOMPANION_AUTH_USERNAME: 'user'
       KOMPANION_AUTH_PASSWORD: 'password'

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -387,6 +387,16 @@ func TestWebStats(t *testing.T) {
 		Expect().Status().Equal(http.StatusOK),
 		Expect().Body().String().Contains("Crime and Punishment"),
 	)
+
+	// regress for uploading same file
+	// https://github.com/vanadium23/kompanion/issues/22
+	Test(t,
+		Description("Kompanion Upload Stats via WebDAV"),
+		Put(basePath+"/webdav/statistics.sqlite3"),
+		Send().Headers("Authorization").Add(basicAuth),
+		Send().Body().Bytes(statsContent),
+		Expect().Status().Equal(http.StatusCreated),
+	)
 }
 
 // HTTP test kompanion shelf feature

--- a/internal/controller/http/webdav/router.go
+++ b/internal/controller/http/webdav/router.go
@@ -14,7 +14,6 @@ func NewRouter(
 	a auth.AuthInterface,
 	l logger.Interface,
 	rs stats.ReadingStats,
-	dirPath string,
 ) {
 	// Options
 	handler.Use(gin.Logger())

--- a/internal/stats/interface.go
+++ b/internal/stats/interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
 	"time"
 )
 
@@ -28,5 +27,4 @@ type ReadingStats interface {
 	GetGeneralStats(ctx context.Context, from, to time.Time) (*GeneralStats, error)
 	GetDailyStats(ctx context.Context, from, to time.Time) ([]DailyStats, error)
 	Write(ctx context.Context, r io.ReadCloser, deviceName string) error
-	Read(ctx context.Context) (*os.File, error)
 }


### PR DESCRIPTION
Previously, KOmpanion returns last saved statistics files. But it was deleted due to messing up with primary keys.

Closes #22